### PR TITLE
Move cpy-cli from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cordova-plugin-splashscreen": "6.0.0",
     "cordova-plugin-whitelist": "1.3.4",
     "cordova-plugin-statusbar": "2.4.3",
+    "cpy-cli": "^3.1.1",
     "monaca-plugin-monaca-core": "3.3.1",
     "dom7": "^3.0.0",
     "framework7": "^6.0.11",
@@ -39,7 +40,6 @@
   },
   "devDependencies": {
     "cordova": "^10.0.0",
-    "cpy-cli": "^3.1.1",
     "browser-sync": "^2.26.7"
   }
 }


### PR DESCRIPTION
Currently builds fail on Monaca while using this template because Monaca uses `npm install --production`, which does not install devDepdencies. The `postinstall` script relies on `cpy-cli` which is not installed with `npm install --production`:

```
$ npm i --production

> framework7-tab-view@1.0.0 postinstall
> cpy ./node_modules/framework7-icons/fonts/*.* ./www/fonts/

sh: 1: cpy: not found
```

I moved `cpy-cli` from the `devDependencies` section to the `depdencies` section. I am not sure if this is the best solution but it fixes the problem.